### PR TITLE
Fixed 404 error with thank you page

### DIFF
--- a/content/donate/thank-you.md
+++ b/content/donate/thank-you.md
@@ -6,8 +6,8 @@ layout: single
 ---
 
 ---- 
-
+Thank you very much for showing your support for Haiku. A receipt for your donation has been sent to your mailbox.
 Your financial contribution is much appreciated.
 Every dollar you contribute helps fuel the development and adoption of our great operating system, Haiku®. We will strive to ensure that it is spent in the best possible manner.
 
-Thank you, on behalf of Haiku, Inc. and the Haiku Project at large.
+On behalf of Haiku, Inc. and the Haiku Project at large, thank you!


### PR DESCRIPTION
Turns out PayPal is redirecting donors to the page "thank-you" - our current thank you page is called "thank_you" so I've renamed that to "thank-you" to fix the 404.